### PR TITLE
fix: add support of home assistant 2025.10

### DIFF
--- a/src/aria2-card.ts
+++ b/src/aria2-card.ts
@@ -13,7 +13,7 @@ export class Aria2Card extends LitElement {
       align-items: center;
     }
 
-    .start-download-row > paper-input {
+    .start-download-row > .addBox {
       flex-grow: 1;
     }
 
@@ -26,14 +26,12 @@ export class Aria2Card extends LitElement {
       display: flex;
       flex-direction: row;
       align-items: center;
-      z-index: 1100;
       position: relative
     }
 
     .progress {
       height: 100%;
       position: absolute;
-      z-index: 1000;
       top: 0;
       background-color: var(--mdc-select-fill-color);
       transition: width 3000ms linear;
@@ -68,15 +66,13 @@ export class Aria2Card extends LitElement {
       <ha-card>
         <div class="card-content">
           <div class="start-download-row">
-            <paper-input
-              no-label-float
-              class="addBox"
-              placeholder="url of the file to download"
-              @keydown=${this.startDownloadOnEnter}
-            ></paper-input>
-            <ha-icon-button @click="${this.startDownload}">
-              <ha-icon style="display: flex" icon="hass:play"></ha-icon>
-            </ha-icon-button>
+            <ha-textfield icon class="addBox" iconTrailing="true" placeholder="Url of the file to download" @keydown=${this.startDownloadOnEnter}>
+              <div class="trailing" slot="trailingIcon">
+                <ha-icon-button @click="${this.startDownload}">
+                  <ha-icon style="display: flex" icon="hass:play"></ha-icon>
+                </ha-icon-button>
+              </div>
+            </ha-textfield> 
           </div>
           <div class="download-list">
             ${

--- a/src/download-detail-dialog.ts
+++ b/src/download-detail-dialog.ts
@@ -5,35 +5,17 @@ import { Download, remainingDurationInSeconds, downloadedPercent } from './downl
 @customElement('download-detail-dialog')
 export class DownloadDetailDialog extends LitElement {
   static override styles = css`
+    .dialog-small {
+      --mdc-dialog-min-width: auto;
+      --mdc-dialog-min-height: auto;
+      z-index: 2000;
+    }
+    
     .label {
       color: var(--secondary-text-color);
     }
     .value {
       color: var(--primary-text-color);
-    }
-
-    ha-header-bar {
-      --mdc-theme-on-primary: var(--primary-text-color);
-      --mdc-theme-primary: var(--mdc-theme-surface);
-      flex-shrink: 0;
-      display: block;
-      border-bottom: 1px solid var(--mdc-dialog-scroll-divider-color, rgba(0, 0, 0, 0.12));
-    }
-
-    @media (max-width: 450px), (max-height: 500px) {
-      ha-dialog {
-          --mdc-dialog-min-width: calc( 100vw - env(safe-area-inset-right) - env(safe-area-inset-left) );
-          --mdc-dialog-max-width: calc( 100vw - env(safe-area-inset-right) - env(safe-area-inset-left) );
-          --mdc-dialog-min-height: 100%;
-          --mdc-dialog-max-height: 100%;
-          --vertial-align-dialog: flex-end;
-          --ha-dialog-border-radius: 0px;
-      }
-
-      ha-header-bar {
-        --mdc-theme-primary: var(--app-header-background-color);
-        --mdc-theme-on-primary: var(--app-header-text-color, white);
-      }
     }
   `;
 
@@ -55,7 +37,7 @@ export class DownloadDetailDialog extends LitElement {
     }
 
     return html`
-      <ha-dialog open hideactions heading=${this.currentDownload.name} @closed=${this.closeDetail}>
+      <ha-dialog class="dialog-small" open hideactions heading=${this.currentDownload.name} @closed=${this.closeDetail}>
         <div>
           <span class="label">file: </span> <span class="value">${this.currentDownload.name}</span> <br/>
           <span class="label">status: </span> <span class="value">${this.currentDownload.status}</span><br/>
@@ -63,14 +45,12 @@ export class DownloadDetailDialog extends LitElement {
           ${downloadData}
         </div>
 
-        <ha-header-bar slot="heading">
+        <ha-dialog-header slot="heading">
           <ha-icon-button slot="navigationIcon" dialogAction="cancel">
             <ha-icon style="display: flex" icon="mdi:close"></ha-icon>
           </ha-icon-button>
-          <div slot="title" class="main-title">
-            ${this.currentDownload.name}
-          </div>
-        </ha-header-bar>
+          <span slot="title">${this.currentDownload.name}</span>
+        </ha-dialog-header>
       </ha-dialog>
       `;
   }


### PR DESCRIPTION
- fix "add download" input  display (use ha-textfield instead of paper-input)
- fix dialog size , and overlap with card